### PR TITLE
created hyperlinked product list

### DIFF
--- a/bangazon/bangazon_ui/templates/bangazon_ui/product_type_list.html
+++ b/bangazon/bangazon_ui/templates/bangazon_ui/product_type_list.html
@@ -5,7 +5,7 @@
    		<br>
         <li><a href="/product_list/{{key.pk}}/"><h4>{{key.label}}({{val|length}})</h4></a></li>
         {%for item in val%}<br>
-        <p>{{item.name}}</p>
+        <p><a href="/product_detail/{{item.pk}}/">{{item.name}}</a></p>
         <p>${{item.price}}</p>
         {%endfor%}
     {%endfor%}


### PR DESCRIPTION
# Description
When you go to the product list page, all the displayed products are not hyperlinked. When you click each product, it goes straight to the detail view

# Related Ticket(s)
#89

## Testing

[ ] There are new unit tests in this PR, and I verify that there is full coverage of all new code.
[ ] I certify that all existing tests pass

## Documentation

[x ] There is new documentation in this pull request that must be reviewed..



## Steps to Test

1. go to your browser, click product type, click each product. It goes to the product detail